### PR TITLE
Add tests for name conformance in Oracle sink

### DIFF
--- a/target_oracle/tests/test_name_conformance.py
+++ b/target_oracle/tests/test_name_conformance.py
@@ -1,0 +1,34 @@
+import pytest
+
+from target_oracle.sinks import OracleSink
+
+
+@pytest.fixture
+def sink():
+    # Use __new__ to bypass __init__ which requires DB connectivity.
+    return OracleSink.__new__(OracleSink)
+
+
+def test_snakecase_conversion(sink):
+    assert sink.snakecase('CustomerIDNumber') == 'customer_id_number'
+
+
+def test_move_leading_underscores(sink):
+    assert sink.move_leading_underscores('__CustomerID') == 'CustomerID__'
+    assert sink.move_leading_underscores('NormalName') == 'NormalName'
+
+
+def test_conform_name_camelcase(sink):
+    assert sink.conform_name('CustomerIDNumber') == 'customer_id_number'
+
+
+def test_conform_name_leading_underscores(sink):
+    assert sink.conform_name('__CustomerIDNumber') == 'customer_id_number__'
+
+
+def test_conform_name_special_chars(sink):
+    assert sink.conform_name('foo-bar') == 'foo_bar'
+
+
+def test_conform_name_leading_digit(sink):
+    assert sink.conform_name('1abc') == 'babc'


### PR DESCRIPTION
## Summary
- add unit tests for OracleSink name conformance utilities

## Testing
- `pytest target_oracle/tests/test_name_conformance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890fb278c54832f8a1187d0820907ce